### PR TITLE
provide CassFormatDecoder for java.util.Date

### DIFF
--- a/src/main/scala/com/weather/scalacass/CassFormatDecoder.scala
+++ b/src/main/scala/com/weather/scalacass/CassFormatDecoder.scala
@@ -135,12 +135,16 @@ trait LowPriorityCassFormatDecoder {
       def decode(r: Row, name: String): Either[Throwable, Map[A, B]] =
         tryDecodeE(r, name, (rr, nn) => f2t(rr.getMap(nn, underlyingA.clazz, underlyingB.clazz)))
     }
-  implicit val dateTimeFormat = new CassFormatDecoder[DateTime] {
+
+  implicit val dateFormat = new CassFormatDecoder[java.util.Date] {
     type From = java.util.Date
     val clazz = classOf[java.util.Date]
-    def f2t(f: From) = Try(new DateTime(f)).toEither
+    def f2t(f: From) = Right(f)
     def decode(r: Row, name: String) = tryDecodeE(r, name, (rr, nn) => f2t(r.getDate(name)))
   }
+
+  implicit val dateTimeFormat: CassFormatDecoder[DateTime] =
+    dateFormat.flatMap(d => Try(new DateTime(d)).toEither)
 
   implicit val blobFormat = new CassFormatDecoder[Array[Byte]] {
     type From = java.nio.ByteBuffer


### PR DESCRIPTION
Hi, great library you have.

Can I recommend you create a Decoder for the date as provided by the datastax row.  This will allow consumers to avoid joda.datetime if they want.