### PR TITLE
using a `NotRecoverable` to allow for really bad failures to just fai…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ javaVersion := sys.props("java.specification.version")
 val cassV3 = "3"
 val cassV21 = "21"
 val cassVersion = SettingKey[String]("cassVersion", "the version of cassandra to use for compilation")
-cassVersion := Option(System.getProperty("cassVersion")).getOrElse(javaVersion.value match {
+cassVersion := sys.props.getOrElse("cassVersion", javaVersion.value match {
   case "1.7" => cassV21
   case _     => cassV3
 })
@@ -41,8 +41,13 @@ scalacOptions ++= Seq(
   "-Xfuture"
 ) ++ (CrossVersion.partialVersion(scalaVersion.value) match {
   case Some((2, 11)) => Seq("-Ywarn-unused", "-Ywarn-unused-import")
-  case _ => Seq.empty[String]
+  case _             => Seq.empty
 })
+
+initialize <<= scalaVersion { sv => CrossVersion.partialVersion(sv) match {
+  case Some((2, 10)) => sys.props("scalac.patmat.analysisBudget") = "512"
+  case _             => sys.props remove "scalac.patmat.analysisBudget"
+}}
 
 scalacOptions in (Compile, console) ~= (_ filterNot (_ == "-Ywarn-unused-import"))
 scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=0.13.12

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.12
+sbt.version=0.13.11

--- a/src/main/scala/com/weather/scalacass/CCCassFormatDecoder.scala
+++ b/src/main/scala/com/weather/scalacass/CCCassFormatDecoder.scala
@@ -18,7 +18,7 @@ trait CCCassFormatDecoder[T] { self =>
     case Left(exc) => throw exc
   }
   final def getAs(r: Row): Option[T] = decode(r).right.toOption
-  final def getOrElse(r: Row)(default: T): T = decode(r).right.getOrElse(default)
+  final def getOrElse(r: Row)(default: => T): T = decode(r).right.getOrElse(default)
   final def attemptAs(r: Row): Either[Throwable, T] = decode(r)
 }
 

--- a/src/main/scala/com/weather/scalacass/CassFormatDecoder.scala
+++ b/src/main/scala/com/weather/scalacass/CassFormatDecoder.scala
@@ -4,8 +4,9 @@ import java.nio.ByteBuffer
 
 import com.datastax.driver.core.{DataType, Row, TupleValue}
 import com.datastax.driver.core.exceptions.{InvalidTypeException, QueryExecutionException}
+import NotRecoverable.Try2Either
 
-import scala.util.{Try, Failure => TFailure, Success => TSuccess}
+import scala.util.Try
 
 trait CassFormatDecoder[T] { self =>
   import CassFormatDecoder.ValueNotDefinedException
@@ -17,18 +18,12 @@ trait CassFormatDecoder[T] { self =>
   private[scalacass] def decode(r: Row, name: String): Either[Throwable, T] = Try[Either[Throwable, T]](
     if (r.isNull(name)) Left(new ValueNotDefinedException(s""""$name" was not defined in ${r.getColumnDefinitions.getTable(name)}"""))
     else f2t(extract(r, name))
-  ) match {
-      case TSuccess(v) => v
-      case TFailure(e) => Left(e)
-    }
+  ).unwrap[T]
   private[scalacass] def tupleExtract(tup: TupleValue, pos: Int): From
   private[scalacass] def tupleDecode(tup: TupleValue, pos: Int): Either[Throwable, T] = Try[Either[Throwable, T]](
     if (tup.isNull(pos)) Left(new ValueNotDefinedException(s"""position $pos was not defined in tuple $tup"""))
     else f2t(tupleExtract(tup, pos))
-  ) match {
-      case TSuccess(v) => v
-      case TFailure(e) => Left(e)
-    }
+  ).unwrap[T]
   final def map[U](fn: T => U): CassFormatDecoder[U] = new CassFormatDecoder[U] {
     type From = self.From
     val clazz = self.clazz
@@ -78,12 +73,12 @@ object CassFormatDecoder extends CassFormatDecoderVersionSpecific {
   type Aux[T, From0] = CassFormatDecoder[T] { type From = From0 }
   def apply[T: CassFormatDecoder] = implicitly[CassFormatDecoder[T]]
 
-  private[scalacass] implicit class TryEither[T](val t: Try[T]) extends AnyVal {
-    def toEither: Either[Throwable, T] = t match {
-      case TSuccess(s) => Right(s)
-      case TFailure(f) => Left(f)
-    }
-  }
+  //  private[scalacass] implicit class TryEither[T](val t: Try[T]) extends AnyVal {
+  //    def toEither: Either[Throwable, T] = t match {
+  //      case TSuccess(s) => Right(s)
+  //      case TFailure(f) => Left(f)
+  //    }
+  //  }
 
   class ValueNotDefinedException(m: String) extends QueryExecutionException(m)
 
@@ -196,10 +191,7 @@ object CassFormatDecoder extends CassFormatDecoderVersionSpecific {
           Left(new InvalidTypeException(s"Column $name is a $cassName, is not a blob"))
         else f2t(extract(r, name))
       }
-    ) match {
-      case TSuccess(v) => v
-      case TFailure(e) => Left(e)
-    }
+    ).unwrap[Array[Byte]]
     def tupleExtract(tup: TupleValue, pos: Int): ByteBuffer = tup getBytes pos
     override def tupleDecode(tup: TupleValue, pos: Int): Either[Throwable, Array[Byte]] = Try[Either[Throwable, Array[Byte]]](
       if (tup.isNull(pos)) Left(new ValueNotDefinedException(s"""position $pos was not defined in tuple $tup"""))
@@ -209,10 +201,7 @@ object CassFormatDecoder extends CassFormatDecoderVersionSpecific {
           Left(new InvalidTypeException(s"position $pos in tuple $tup is not a blob"))
         else f2t(tupleExtract(tup, pos))
       }
-    ) match {
-      case TSuccess(v) => v
-      case TFailure(e) => Left(e)
-    }
+    ).unwrap[Array[Byte]]
   }
 
   implicit def optionFormat[A](implicit underlying: CassFormatDecoder[A]): CassFormatDecoder[Option[A]] = new CassFormatDecoder[Option[A]] {

--- a/src/main/scala/com/weather/scalacass/CassFormatDecoder.scala
+++ b/src/main/scala/com/weather/scalacass/CassFormatDecoder.scala
@@ -44,7 +44,7 @@ trait CassFormatDecoder[T] { self =>
     case Left(exc) => throw exc
   }
   final def getAs(r: Row)(name: String): Option[T] = decode(r, name).right.toOption
-  final def getOrElse(r: Row)(name: String, default: T): T = decode(r, name).right.getOrElse(default)
+  final def getOrElse(r: Row)(name: String, default: => T): T = decode(r, name).right.getOrElse(default)
   final def attemptAs(r: Row)(name: String): Either[Throwable, T] = decode(r, name)
 }
 

--- a/src/main/scala/com/weather/scalacass/CassFormatDecoder.scala
+++ b/src/main/scala/com/weather/scalacass/CassFormatDecoder.scala
@@ -73,13 +73,6 @@ object CassFormatDecoder extends CassFormatDecoderVersionSpecific {
   type Aux[T, From0] = CassFormatDecoder[T] { type From = From0 }
   def apply[T: CassFormatDecoder] = implicitly[CassFormatDecoder[T]]
 
-  //  private[scalacass] implicit class TryEither[T](val t: Try[T]) extends AnyVal {
-  //    def toEither: Either[Throwable, T] = t match {
-  //      case TSuccess(s) => Right(s)
-  //      case TFailure(f) => Left(f)
-  //    }
-  //  }
-
   class ValueNotDefinedException(m: String) extends QueryExecutionException(m)
 
   private[scalacass] def sameTypeCassFormatDecoder[T <: AnyRef](_clazz: Class[T], _extract: (Row, String) => T, _tupExtract: (TupleValue, Int) => T) = new CassFormatDecoder[T] {

--- a/src/main/scala/com/weather/scalacass/NotRecoverable.scala
+++ b/src/main/scala/com/weather/scalacass/NotRecoverable.scala
@@ -1,0 +1,24 @@
+package com.weather.scalacass
+
+import com.datastax.driver.core.exceptions.TransportException
+
+object NotRecoverable {
+  def apply(t: Throwable): Boolean = t match {
+    case _: TransportException => true
+    case _                     => false
+  }
+  def unapply(t: Throwable): Option[Throwable] = if (apply(t)) Some(t) else None
+
+  implicit class Try2Either[T](val t: scala.util.Try[T]) extends AnyVal {
+    def unwrap[S](implicit ev: T =:= Either[Throwable, S]): Either[Throwable, S] = t match {
+      case scala.util.Success(res)                 => res
+      case scala.util.Failure(NotRecoverable(exc)) => throw exc
+      case scala.util.Failure(exc)                 => Left(exc)
+    }
+    def toEither: Either[Throwable, T] = t match {
+      case scala.util.Success(res)                 => Right(res)
+      case scala.util.Failure(NotRecoverable(exc)) => throw exc
+      case scala.util.Failure(exc)                 => Left(exc)
+    }
+  }
+}

--- a/src/main/scala/com/weather/scalacass/NotRecoverable.scala
+++ b/src/main/scala/com/weather/scalacass/NotRecoverable.scala
@@ -1,12 +1,6 @@
 package com.weather.scalacass
 
-import com.datastax.driver.core.exceptions.TransportException
-
-object NotRecoverable {
-  def apply(t: Throwable): Boolean = t match {
-    case _: TransportException => true
-    case _                     => false
-  }
+object NotRecoverable extends NotRecoverableVersionSpecific {
   def unapply(t: Throwable): Option[Throwable] = if (apply(t)) Some(t) else None
 
   implicit class Try2Either[T](val t: scala.util.Try[T]) extends AnyVal {

--- a/src/main/scala/com/weather/scalacass/syntax.scala
+++ b/src/main/scala/com/weather/scalacass/syntax.scala
@@ -6,12 +6,36 @@ object syntax {
   implicit class RichRow(val r: Row) extends AnyVal {
     def as[T](name: String)(implicit d: CassFormatDecoder[T]): T = d.as(r)(name)
     def getAs[T](name: String)(implicit d: CassFormatDecoder[T]): Option[T] = d.getAs(r)(name)
-    def getOrElse[T](name: String, default: T)(implicit d: CassFormatDecoder[T]): T = d.getOrElse(r)(name, default)
+    def getOrElse[T](name: String, default: => T)(implicit d: CassFormatDecoder[T]): T = d.getOrElse(r)(name, default)
     def attemptAs[T](name: String)(implicit d: CassFormatDecoder[T]): Either[Throwable, T] = d.attemptAs(r)(name)
 
     def as[T](implicit ccd: CCCassFormatDecoder[T]): T = ccd.as(r)
     def getAs[T](implicit ccd: CCCassFormatDecoder[T]): Option[T] = ccd.getAs(r)
-    def getOrElse[T](default: T)(implicit ccd: CCCassFormatDecoder[T]): T = ccd.getOrElse(r)(default)
+    def getOrElse[T](default: => T)(implicit ccd: CCCassFormatDecoder[T]): T = ccd.getOrElse(r)(default)
     def attemptAs[T](implicit ccd: CCCassFormatDecoder[T]): Either[Throwable, T] = ccd.attemptAs(r)
+  }
+  
+  implicit class RichIterator(val it: Iterator[Row]) extends AnyVal {
+    def as[T](name: String)(implicit d: CassFormatDecoder[T]): Iterator[T] = it.map(r => d.as(r)(name))
+    def getAs[T](name: String)(implicit d: CassFormatDecoder[T]): Iterator[Option[T]] = it.map(r => d.getAs(r)(name))
+    def getOrElse[T](name: String, default: => T)(implicit d: CassFormatDecoder[T]): Iterator[T] = it.map(r => d.getOrElse(r)(name, default))
+    def attemptAs[T](name: String)(implicit d: CassFormatDecoder[T]): Iterator[Either[Throwable, T]] = it.map(r => d.attemptAs(r)(name))
+
+    def as[T](implicit ccd: CCCassFormatDecoder[T]): Iterator[T] = it.map(r => ccd.as(r))
+    def getAs[T](implicit ccd: CCCassFormatDecoder[T]): Iterator[Option[T]] = it.map(r => ccd.getAs(r))
+    def getOrElse[T](default: => T)(implicit ccd: CCCassFormatDecoder[T]): Iterator[T] = it.map(r => ccd.getOrElse(r)(default))
+    def attemptAs[T](implicit ccd: CCCassFormatDecoder[T]): Iterator[Either[Throwable, T]] = it.map(r => ccd.attemptAs(r))
+  }
+
+  implicit class RichOption(val opt: Option[Row]) extends AnyVal {
+    def as[T](name: String)(implicit d: CassFormatDecoder[T]): Option[T] = opt.map(r => d.as(r)(name))
+    def getAs[T](name: String)(implicit d: CassFormatDecoder[T]): Option[Option[T]] = opt.map(r => d.getAs(r)(name))
+    def getOrElse[T](name: String, default: => T)(implicit d: CassFormatDecoder[T]): Option[T] = opt.map(r => d.getOrElse(r)(name, default))
+    def attemptAs[T](name: String)(implicit d: CassFormatDecoder[T]): Option[Either[Throwable, T]] = opt.map(r => d.attemptAs(r)(name))
+
+    def as[T](implicit ccd: CCCassFormatDecoder[T]): Option[T] = opt.map(r => ccd.as(r))
+    def getAs[T](implicit ccd: CCCassFormatDecoder[T]): Option[Option[T]] = opt.map(r => ccd.getAs(r))
+    def getOrElse[T](default: => T)(implicit ccd: CCCassFormatDecoder[T]): Option[T] = opt.map(r => ccd.getOrElse(r)(default))
+    def attemptAs[T](implicit ccd: CCCassFormatDecoder[T]): Option[Either[Throwable, T]] = opt.map(r => ccd.attemptAs(r))
   }
 }

--- a/src/main/scala_cass21/com/weather/scalacass/NotRecoverableVersionSpecific.scala
+++ b/src/main/scala_cass21/com/weather/scalacass/NotRecoverableVersionSpecific.scala
@@ -1,0 +1,11 @@
+package com.weather.scalacass
+
+import com.datastax.driver.core.exceptions.{NoHostAvailableException, QueryExecutionException, DriverInternalError, PagingStateException, UnsupportedFeatureException}
+
+trait NotRecoverableVersionSpecific {
+  def apply(t: Throwable): Boolean = {
+    case _: NoHostAvailableException | _: QueryExecutionException | _: DriverInternalError | _: PagingStateException |
+         _: UnsupportedOperationException => true
+    case _                                => false
+  }
+}

--- a/src/main/scala_cass21/com/weather/scalacass/NotRecoverableVersionSpecific.scala
+++ b/src/main/scala_cass21/com/weather/scalacass/NotRecoverableVersionSpecific.scala
@@ -3,9 +3,9 @@ package com.weather.scalacass
 import com.datastax.driver.core.exceptions.{NoHostAvailableException, QueryExecutionException, DriverInternalError, PagingStateException, UnsupportedFeatureException}
 
 trait NotRecoverableVersionSpecific {
-  def apply(t: Throwable): Boolean = {
+  def apply(t: Throwable): Boolean = t match {
     case _: NoHostAvailableException | _: QueryExecutionException | _: DriverInternalError | _: PagingStateException |
-         _: UnsupportedOperationException => true
-    case _                                => false
+      _: UnsupportedFeatureException => true
+    case _ => false
   }
 }

--- a/src/main/scala_cass3/com/weather/scalacass/NotRecoverableVersionSpecific.scala
+++ b/src/main/scala_cass3/com/weather/scalacass/NotRecoverableVersionSpecific.scala
@@ -1,0 +1,13 @@
+package com.weather.scalacass
+
+import com.datastax.driver.core.exceptions.{TransportException, QueryExecutionException, NoHostAvailableException, BusyConnectionException, ConnectionException, DriverInternalError, PagingStateException, QueryExecutionException, UnsupportedFeatureException, UnsupportedProtocolVersionException}
+
+trait NotRecoverableVersionSpecific {
+  def apply(t: Throwable) = t match {
+    case _: TransportException | _: QueryExecutionException | _: NoHostAvailableException |
+         _: BusyConnectionException | _: ConnectionException | _: DriverInternalError |
+         _: PagingStateException | _: QueryExecutionException | _: UnsupportedFeatureException |
+         _: UnsupportedProtocolVersionException => true
+    case _                                      => false
+  }
+}

--- a/src/main/scala_cass3/com/weather/scalacass/NotRecoverableVersionSpecific.scala
+++ b/src/main/scala_cass3/com/weather/scalacass/NotRecoverableVersionSpecific.scala
@@ -1,13 +1,13 @@
 package com.weather.scalacass
 
-import com.datastax.driver.core.exceptions.{TransportException, QueryExecutionException, NoHostAvailableException, BusyConnectionException, ConnectionException, DriverInternalError, PagingStateException, QueryExecutionException, UnsupportedFeatureException, UnsupportedProtocolVersionException}
+import com.datastax.driver.core.exceptions.{TransportException, QueryExecutionException, NoHostAvailableException, BusyConnectionException, ConnectionException, DriverInternalError, PagingStateException, UnsupportedFeatureException, UnsupportedProtocolVersionException}
 
 trait NotRecoverableVersionSpecific {
   def apply(t: Throwable) = t match {
     case _: TransportException | _: QueryExecutionException | _: NoHostAvailableException |
-         _: BusyConnectionException | _: ConnectionException | _: DriverInternalError |
-         _: PagingStateException | _: QueryExecutionException | _: UnsupportedFeatureException |
-         _: UnsupportedProtocolVersionException => true
-    case _                                      => false
+      _: BusyConnectionException | _: ConnectionException | _: DriverInternalError |
+      _: PagingStateException | _: UnsupportedFeatureException |
+      _: UnsupportedProtocolVersionException => true
+    case _ => false
   }
 }


### PR DESCRIPTION
…l. Looking for more "really bad failures"

Primary use case is when you have an `Iterator[Row]`, and trying to read from a downed cassandra will result in all `None`s (assuming `getAs`). This is confusing because the problem has nothing to do with extraction, but with communication, so let specific errors actually throw