### PR TITLE
in the event of nested data types (eg, `map<uuid, set<uuid>>`), new v…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ version := {
     case (`cassV21`, "1.7") => "5"
     case (cv, jv) => throw new RuntimeException("invalid cassandra/java version combination: " + cv + "/" + jv + ". use either cass \"" + cassV3 + "\" with java 8 or cass \"" + cassV21 + "\" with java 7")
   }
-  s"0.$majorVersion.13"
+  s"0.$majorVersion.14"
 }
 
 scalaVersion := "2.11.8"

--- a/src/main/scala/com/weather/scalacass/CassFormatDecoder.scala
+++ b/src/main/scala/com/weather/scalacass/CassFormatDecoder.scala
@@ -5,6 +5,7 @@ import java.nio.ByteBuffer
 import com.datastax.driver.core.{DataType, Row, TupleValue}
 import com.datastax.driver.core.exceptions.{InvalidTypeException, QueryExecutionException}
 import NotRecoverable.Try2Either
+import com.google.common.reflect.{TypeParameter, TypeToken}
 
 import scala.util.Try
 
@@ -12,7 +13,7 @@ trait CassFormatDecoder[T] { self =>
   import CassFormatDecoder.ValueNotDefinedException
 
   private[scalacass]type From <: AnyRef
-  private[scalacass] def clazz: Class[From]
+  private[scalacass] def typeToken: TypeToken[From]
   private[scalacass] def f2t(f: From): Either[Throwable, T]
   private[scalacass] def extract(r: Row, name: String): From
   private[scalacass] def decode(r: Row, name: String): Either[Throwable, T] = Try[Either[Throwable, T]](
@@ -26,14 +27,14 @@ trait CassFormatDecoder[T] { self =>
   ).unwrap[T]
   final def map[U](fn: T => U): CassFormatDecoder[U] = new CassFormatDecoder[U] {
     type From = self.From
-    val clazz = self.clazz
+    val typeToken = self.typeToken
     def f2t(f: From): Either[Throwable, U] = self.f2t(f).right.map(fn)
     def extract(r: Row, name: String): From = self.extract(r, name)
     def tupleExtract(tup: TupleValue, pos: Int): From = self.tupleExtract(tup, pos)
   }
   final def flatMap[U](fn: T => Either[Throwable, U]): CassFormatDecoder[U] = new CassFormatDecoder[U] {
     type From = self.From
-    val clazz = self.clazz
+    val typeToken = self.typeToken
     def f2t(f: From): Either[Throwable, U] = self.f2t(f).right.flatMap(fn)
     def extract(r: Row, name: String): From = self.extract(r, name)
     def tupleExtract(tup: TupleValue, pos: Int): From = self.tupleExtract(tup, pos)
@@ -52,7 +53,7 @@ trait CassFormatDecoder[T] { self =>
 trait LowPriorityCassFormatDecoder {
   implicit def tupleFormat[TUP <: Product](implicit underlying: TupleCassFormatDecoder[TUP]): CassFormatDecoder[TUP] = new CassFormatDecoder[TUP] {
     type From = TupleValue
-    val clazz = classOf[TupleValue]
+    val typeToken = TypeToken.of(classOf[TupleValue])
     def f2t(f: From) = underlying.decode(f, 0)
     def extract(r: Row, name: String) = r getTupleValue name
     def tupleExtract(tup: TupleValue, pos: Int) = tup getTupleValue pos
@@ -75,16 +76,16 @@ object CassFormatDecoder extends CassFormatDecoderVersionSpecific {
 
   class ValueNotDefinedException(m: String) extends QueryExecutionException(m)
 
-  private[scalacass] def sameTypeCassFormatDecoder[T <: AnyRef](_clazz: Class[T], _extract: (Row, String) => T, _tupExtract: (TupleValue, Int) => T) = new CassFormatDecoder[T] {
+  private[scalacass] def sameTypeCassFormatDecoder[T <: AnyRef](_typeToken: TypeToken[T], _extract: (Row, String) => T, _tupExtract: (TupleValue, Int) => T) = new CassFormatDecoder[T] {
     type From = T
-    val clazz = _clazz
+    val typeToken = _typeToken
     def f2t(f: From) = Right(f)
     def extract(r: Row, name: String) = _extract(r, name)
     def tupleExtract(tup: TupleValue, pos: Int): T = _tupExtract(tup, pos)
   }
-  def safeConvertCassFormatDecoder[T, F <: AnyRef](_clazz: Class[F], _f2t: F => T, _extract: (Row, String) => F, _tupExtract: (TupleValue, Int) => F) = new CassFormatDecoder[T] {
+  def safeConvertCassFormatDecoder[T, F <: AnyRef](_typeToken: TypeToken[F], _f2t: F => T, _extract: (Row, String) => F, _tupExtract: (TupleValue, Int) => F) = new CassFormatDecoder[T] {
     type From = F
-    val clazz = _clazz
+    val typeToken = _typeToken
     def f2t(f: From) = Right(_f2t(f))
     def extract(r: Row, name: String) = _extract(r, name)
     def tupleExtract(tup: TupleValue, pos: Int) = _tupExtract(tup, pos)
@@ -92,22 +93,25 @@ object CassFormatDecoder extends CassFormatDecoderVersionSpecific {
 
   // decoders
 
-  implicit val stringFormat = sameTypeCassFormatDecoder(classOf[String], _ getString _, _ getString _)
-  implicit val uuidFormat = sameTypeCassFormatDecoder(classOf[java.util.UUID], _ getUUID _, _ getUUID _)
-  implicit val iNetFormat = sameTypeCassFormatDecoder[java.net.InetAddress](classOf[java.net.InetAddress], _ getInet _, _ getInet _)
+  implicit val stringFormat = sameTypeCassFormatDecoder(TypeToken.of(classOf[String]), _ getString _, _ getString _)
+  implicit val uuidFormat = sameTypeCassFormatDecoder(TypeToken.of(classOf[java.util.UUID]), _ getUUID _, _ getUUID _)
+  implicit val iNetFormat = sameTypeCassFormatDecoder[java.net.InetAddress](TypeToken.of(classOf[java.net.InetAddress]), _ getInet _, _ getInet _)
 
-  implicit val intFormat = safeConvertCassFormatDecoder[Int, java.lang.Integer](classOf[java.lang.Integer], Int.unbox, _ getInt _, _ getInt _)
+  implicit val intFormat = safeConvertCassFormatDecoder[Int, java.lang.Integer](TypeToken.of(classOf[java.lang.Integer]), Int.unbox, _ getInt _, _ getInt _)
 
-  implicit val longFormat = safeConvertCassFormatDecoder[Long, java.lang.Long](classOf[java.lang.Long], Long.unbox, _ getLong _, _ getLong _)
-  implicit val booleanFormat = safeConvertCassFormatDecoder[Boolean, java.lang.Boolean](classOf[java.lang.Boolean], Boolean.unbox, _ getBool _, _ getBool _)
-  implicit val doubleFormat = safeConvertCassFormatDecoder[Double, java.lang.Double](classOf[java.lang.Double], Double.unbox, _ getDouble _, _ getDouble _)
-  implicit val floatFormat = safeConvertCassFormatDecoder[Float, java.lang.Float](classOf[java.lang.Float], Float.unbox, _ getFloat _, _ getFloat _)
-  implicit val bigIntegerFormat = safeConvertCassFormatDecoder[BigInt, java.math.BigInteger](classOf[java.math.BigInteger], BigInt.javaBigInteger2bigInt, _ getVarint _, _ getVarint _)
-  implicit val bigDecimalFormat = safeConvertCassFormatDecoder[BigDecimal, java.math.BigDecimal](classOf[java.math.BigDecimal], BigDecimal.javaBigDecimal2bigDecimal, _ getDecimal _, _ getDecimal _)
+  implicit val longFormat = safeConvertCassFormatDecoder[Long, java.lang.Long](TypeToken.of(classOf[java.lang.Long]), Long.unbox, _ getLong _, _ getLong _)
+  implicit val booleanFormat = safeConvertCassFormatDecoder[Boolean, java.lang.Boolean](TypeToken.of(classOf[java.lang.Boolean]), Boolean.unbox, _ getBool _, _ getBool _)
+  implicit val doubleFormat = safeConvertCassFormatDecoder[Double, java.lang.Double](TypeToken.of(classOf[java.lang.Double]), Double.unbox, _ getDouble _, _ getDouble _)
+  implicit val floatFormat = safeConvertCassFormatDecoder[Float, java.lang.Float](TypeToken.of(classOf[java.lang.Float]), Float.unbox, _ getFloat _, _ getFloat _)
+  implicit val bigIntegerFormat = safeConvertCassFormatDecoder[BigInt, java.math.BigInteger](TypeToken.of(classOf[java.math.BigInteger]), BigInt.javaBigInteger2bigInt, _ getVarint _, _ getVarint _)
+  implicit val bigDecimalFormat = safeConvertCassFormatDecoder[BigDecimal, java.math.BigDecimal](TypeToken.of(classOf[java.math.BigDecimal]), BigDecimal.javaBigDecimal2bigDecimal, _ getDecimal _, _ getDecimal _)
+
+  private def listOf[T](eltType: TypeToken[T]): TypeToken[java.util.List[T]] =
+    new TypeToken[java.util.List[T]]() {}.where(new TypeParameter[T]() {}, eltType)
 
   implicit def listFormat[T](implicit underlying: CassFormatDecoder[T]) = new CassFormatDecoder[List[T]] {
     type From = java.util.List[underlying.From]
-    val clazz = classOf[From]
+    val typeToken = listOf(underlying.typeToken)
     def f2t(f: From): Either[Throwable, List[T]] = {
       val acc = List.newBuilder[T]
       @scala.annotation.tailrec
@@ -121,13 +125,16 @@ object CassFormatDecoder extends CassFormatDecoderVersionSpecific {
       }
       process(f.listIterator)
     }
-    def extract(r: Row, name: String) = r getList (name, underlying.clazz)
-    def tupleExtract(tup: TupleValue, pos: Int) = tup getList (pos, underlying.clazz)
+    def extract(r: Row, name: String) = r getList (name, underlying.typeToken)
+    def tupleExtract(tup: TupleValue, pos: Int) = tup getList (pos, underlying.typeToken)
   }
+
+  private def setOf[T](eltType: TypeToken[T]): TypeToken[java.util.Set[T]] =
+    new TypeToken[java.util.Set[T]]() {}.where(new TypeParameter[T]() {}, eltType)
 
   implicit def setFormat[T](implicit underlying: CassFormatDecoder[T]) = new CassFormatDecoder[Set[T]] {
     type From = java.util.Set[underlying.From]
-    val clazz = classOf[From]
+    val typeToken: TypeToken[java.util.Set[underlying.From]] = setOf(underlying.typeToken)
     def f2t(f: From): Either[Throwable, Set[T]] = {
       val acc = Set.newBuilder[T]
       @scala.annotation.tailrec
@@ -141,14 +148,19 @@ object CassFormatDecoder extends CassFormatDecoderVersionSpecific {
       }
       process(f.iterator)
     }
-    def extract(r: Row, name: String) = r getSet (name, underlying.clazz)
-    def tupleExtract(tup: TupleValue, pos: Int) = tup getSet (pos, underlying.clazz)
+    def extract(r: Row, name: String) = r getSet (name, underlying.typeToken)
+    def tupleExtract(tup: TupleValue, pos: Int) = tup getSet (pos, underlying.typeToken)
   }
+
+  private def mapOf[K, V](keyType: TypeToken[K], valueType: TypeToken[V]): TypeToken[java.util.Map[K, V]] =
+    new TypeToken[java.util.Map[K, V]]() {}
+      .where(new TypeParameter[K]() {}, keyType)
+      .where(new TypeParameter[V]() {}, valueType)
 
   implicit def mapFormat[K, V](implicit underlyingK: CassFormatDecoder[K], underlyingV: CassFormatDecoder[V]) =
     new CassFormatDecoder[Map[K, V]] {
       type From = java.util.Map[underlyingK.From, underlyingV.From]
-      val clazz = classOf[From]
+      val typeToken = mapOf(underlyingK.typeToken, underlyingV.typeToken)
       def f2t(f: From): Either[Throwable, Map[K, V]] = {
         val acc = Map.newBuilder[K, V]
         @scala.annotation.tailrec
@@ -166,13 +178,13 @@ object CassFormatDecoder extends CassFormatDecoderVersionSpecific {
           }
         process(f.entrySet.iterator)
       }
-      def extract(r: Row, name: String) = r getMap (name, underlyingK.clazz, underlyingV.clazz)
-      def tupleExtract(tup: TupleValue, pos: Int) = tup getMap (pos, underlyingK.clazz, underlyingV.clazz)
+      def extract(r: Row, name: String) = r getMap (name, underlyingK.typeToken, underlyingV.typeToken)
+      def tupleExtract(tup: TupleValue, pos: Int) = tup getMap (pos, underlyingK.typeToken, underlyingV.typeToken)
     }
 
   implicit val blobFormat: CassFormatDecoder[Array[Byte]] = new CassFormatDecoder[Array[Byte]] {
     type From = java.nio.ByteBuffer
-    val clazz = classOf[java.nio.ByteBuffer]
+    val typeToken = TypeToken.of(classOf[java.nio.ByteBuffer])
 
     def f2t(f: From) = Try(com.datastax.driver.core.utils.Bytes.getArray(f).toIndexedSeq.toArray).toEither
     def extract(r: Row, name: String): ByteBuffer = r getBytes name
@@ -199,7 +211,7 @@ object CassFormatDecoder extends CassFormatDecoderVersionSpecific {
 
   implicit def optionFormat[A](implicit underlying: CassFormatDecoder[A]): CassFormatDecoder[Option[A]] = new CassFormatDecoder[Option[A]] {
     type From = underlying.From
-    val clazz = underlying.clazz
+    val typeToken = underlying.typeToken
     def f2t(f: From): Either[Throwable, Option[A]] = underlying.f2t(f).right.map(Option(_))
     def extract(r: Row, name: String) = underlying.extract(r, name)
     override def decode(r: Row, name: String): Either[Throwable, Option[A]] = Right(super.decode(r, name).right getOrElse None)
@@ -210,7 +222,7 @@ object CassFormatDecoder extends CassFormatDecoderVersionSpecific {
 
   implicit def eitherFormat[A](implicit underlying: CassFormatDecoder[A]): CassFormatDecoder[Either[Throwable, A]] = new CassFormatDecoder[Either[Throwable, A]] {
     type From = underlying.From
-    val clazz = underlying.clazz
+    val typeToken = underlying.typeToken
     def f2t(f: From) = Right(underlying.f2t(f))
     def extract(r: Row, name: String) = underlying.extract(r, name)
     override def decode(r: Row, name: String) = super.decode(r, name) match {

--- a/src/main/scala_cass21/com/weather/scalacass/CassFormatDecoderVersionSpecific.scala
+++ b/src/main/scala_cass21/com/weather/scalacass/CassFormatDecoderVersionSpecific.scala
@@ -1,10 +1,12 @@
 package com.weather.scalacass
 
+import com.google.common.reflect.TypeToken
+
 object CassFormatDecoderVersionSpecific extends CassFormatDecoderVersionSpecific
 
 trait CassFormatDecoderVersionSpecific extends LowPriorityCassFormatDecoder {
   import CassFormatDecoder.sameTypeCassFormatDecoder
 
   implicit val dateFormat: CassFormatDecoder[java.util.Date] =
-    sameTypeCassFormatDecoder[java.util.Date](classOf[java.util.Date], _ getDate _, _ getDate _)
+    sameTypeCassFormatDecoder[java.util.Date](TypeToken.of(classOf[java.util.Date]), _ getDate _, _ getDate _)
 }

--- a/src/main/scala_cass3/com/weather/scalacass/CassFormatDecoderVersionSpecific.scala
+++ b/src/main/scala_cass3/com/weather/scalacass/CassFormatDecoderVersionSpecific.scala
@@ -1,21 +1,22 @@
 package com.weather.scalacass
 
 import com.datastax.driver.core.{Row, TupleValue}
+import com.google.common.reflect.TypeToken
 
 object CassFormatDecoderVersionSpecific extends CassFormatDecoderVersionSpecific {
-  def codecCassFormatDecoder[T <: AnyRef](_clazz: Class[T]) = new CassFormatDecoder[T] {
+  def codecCassFormatDecoder[T <: AnyRef](_typeToken: TypeToken[T]) = new CassFormatDecoder[T] {
     type From = T
-    val clazz = _clazz
+    val typeToken = _typeToken
     def f2t(f: From) = Right(f)
-    def extract(r: Row, name: String) = r get (name, clazz)
-    def tupleExtract(tup: TupleValue, pos: Int) = tup get (pos, clazz)
+    def extract(r: Row, name: String) = r get (name, typeToken)
+    def tupleExtract(tup: TupleValue, pos: Int) = tup get (pos, typeToken)
   }
 }
 trait CassFormatDecoderVersionSpecific extends LowPriorityCassFormatDecoder {
   import CassFormatDecoder.{sameTypeCassFormatDecoder, safeConvertCassFormatDecoder}
   implicit val dateFormat: CassFormatDecoder[java.util.Date] =
-    sameTypeCassFormatDecoder[java.util.Date](classOf[java.util.Date], _ getTimestamp _, _ getTimestamp _)
+    sameTypeCassFormatDecoder[java.util.Date](TypeToken.of(classOf[java.util.Date]), _ getTimestamp _, _ getTimestamp _)
   implicit val datastaxLocalDateFormat: CassFormatDecoder[com.datastax.driver.core.LocalDate] =
-    sameTypeCassFormatDecoder[com.datastax.driver.core.LocalDate](classOf[com.datastax.driver.core.LocalDate], _ getDate _, _ getDate _)
-  implicit val timeFormat: CassFormatDecoder[Time] = safeConvertCassFormatDecoder[Time, java.lang.Long](classOf[java.lang.Long], Time.apply(_), _ getTime _, _ getTime _)
+    sameTypeCassFormatDecoder[com.datastax.driver.core.LocalDate](TypeToken.of(classOf[com.datastax.driver.core.LocalDate]), _ getDate _, _ getDate _)
+  implicit val timeFormat: CassFormatDecoder[Time] = safeConvertCassFormatDecoder[Time, java.lang.Long](TypeToken.of(classOf[java.lang.Long]), Time(_), _ getTime _, _ getTime _)
 }

--- a/src/main/scala_cass3/com/weather/scalacass/jdk8/Implicits.scala
+++ b/src/main/scala_cass3/com/weather/scalacass/jdk8/Implicits.scala
@@ -5,19 +5,20 @@ import com.weather.scalacass.CassFormatDecoderVersionSpecific.codecCassFormatDec
 import CassFormatEncoder.sameTypeCassFormatEncoder
 import java.time.{Instant, LocalDate, LocalTime, ZonedDateTime}
 
-import com.datastax.driver.core.{DataType, Cluster}
+import com.datastax.driver.core.{Cluster, DataType}
+import com.google.common.reflect.TypeToken
 
 object Implicits {
   implicit val timeEncoder: CassFormatEncoder[LocalTime] = sameTypeCassFormatEncoder(DataType.time)
-  implicit val timeDecoder: CassFormatDecoder[LocalTime] = codecCassFormatDecoder(classOf[LocalTime])
+  implicit val timeDecoder: CassFormatDecoder[LocalTime] = codecCassFormatDecoder(TypeToken.of(classOf[LocalTime]))
 
   implicit val dateEncoder: CassFormatEncoder[LocalDate] = sameTypeCassFormatEncoder(DataType.date)
-  implicit val dateDecoder: CassFormatDecoder[LocalDate] = codecCassFormatDecoder(classOf[LocalDate])
+  implicit val dateDecoder: CassFormatDecoder[LocalDate] = codecCassFormatDecoder(TypeToken.of(classOf[LocalDate]))
 
   implicit val instantEncoder: CassFormatEncoder[Instant] = sameTypeCassFormatEncoder(DataType.timestamp)
-  implicit val instantDecoder: CassFormatDecoder[Instant] = codecCassFormatDecoder(classOf[Instant])
+  implicit val instantDecoder: CassFormatDecoder[Instant] = codecCassFormatDecoder(TypeToken.of(classOf[Instant]))
 
   implicit def zonedDateTimeEncoder(implicit cluster: Cluster): CassFormatEncoder[ZonedDateTime] =
     sameTypeCassFormatEncoder(cluster.getMetadata.newTupleType(DataType.timestamp, DataType.varchar))
-  implicit val zonedDateTimeDecoder: CassFormatDecoder[ZonedDateTime] = codecCassFormatDecoder(classOf[ZonedDateTime])
+  implicit val zonedDateTimeDecoder: CassFormatDecoder[ZonedDateTime] = codecCassFormatDecoder(TypeToken.of(classOf[ZonedDateTime]))
 }

--- a/src/main/scala_cass3/com/weather/scalacass/joda/Implicits.scala
+++ b/src/main/scala_cass3/com/weather/scalacass/joda/Implicits.scala
@@ -1,6 +1,7 @@
 package com.weather.scalacass.joda
 
 import com.datastax.driver.core.{Cluster, DataType}
+import com.google.common.reflect.TypeToken
 import com.weather.scalacass.{CassFormatDecoder, CassFormatEncoder}
 import com.weather.scalacass.CassFormatEncoder.sameTypeCassFormatEncoder
 import com.weather.scalacass.CassFormatDecoderVersionSpecific.codecCassFormatDecoder
@@ -8,15 +9,15 @@ import org.joda.time.{DateTime, Instant, LocalDate, LocalTime}
 
 object Implicits {
   implicit val timeEncoder: CassFormatEncoder[LocalTime] = sameTypeCassFormatEncoder(DataType.time)
-  implicit val timeDecoder: CassFormatDecoder[LocalTime] = codecCassFormatDecoder(classOf[LocalTime])
+  implicit val timeDecoder: CassFormatDecoder[LocalTime] = codecCassFormatDecoder(TypeToken.of(classOf[LocalTime]))
 
   implicit val dateEncoder: CassFormatEncoder[LocalDate] = sameTypeCassFormatEncoder(DataType.date)
-  implicit val dateDecoder: CassFormatDecoder[LocalDate] = codecCassFormatDecoder(classOf[LocalDate])
+  implicit val dateDecoder: CassFormatDecoder[LocalDate] = codecCassFormatDecoder(TypeToken.of(classOf[LocalDate]))
 
   implicit val instantEncoder: CassFormatEncoder[Instant] = sameTypeCassFormatEncoder(DataType.timestamp)
-  implicit val instantDecoder: CassFormatDecoder[Instant] = codecCassFormatDecoder(classOf[Instant])
+  implicit val instantDecoder: CassFormatDecoder[Instant] = codecCassFormatDecoder(TypeToken.of(classOf[Instant]))
 
   implicit def timestampEncoder(implicit cluster: Cluster): CassFormatEncoder[DateTime] =
     sameTypeCassFormatEncoder(cluster.getMetadata.newTupleType(DataType.timestamp, DataType.varchar))
-  implicit val timestampDecoder: CassFormatDecoder[DateTime] = codecCassFormatDecoder(classOf[DateTime])
+  implicit val timestampDecoder: CassFormatDecoder[DateTime] = codecCassFormatDecoder(TypeToken.of(classOf[DateTime]))
 }


### PR DESCRIPTION
…ersion of cassandra driver will barf if you use Class instances for extraction. Use TypeToken instead to fix it