### PR TITLE
Consistency Level per statement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: scala
 scala:
   - 2.12.6
   - 2.11.12
-  - 2.10.6
+  - 2.10.7
 
 jdk:
   - oraclejdk8

--- a/docs/cass21/src/main/tut/cass21/scalasession/consistency-level.md
+++ b/docs/cass21/src/main/tut/cass21/scalasession/consistency-level.md
@@ -1,0 +1,45 @@
+---
+layout: docs
+title: "Consistency Level"
+section: "c21"
+---
+```tut:invisible
+import com.datastax.driver.core.{Cluster, Session}
+import com.weather.scalacass.ScalaSession
+
+implicit val cluster = Cluster.builder.addContactPoint("localhost").build()
+implicit val session: Session = cluster.connect()
+
+val sSession: ScalaSession = ScalaSession("mykeyspace")
+sSession.createKeyspace("replication = {'class':'SimpleStrategy', 'replication_factor' : 1}").execute()
+
+case class MyTable(s: String, i: Int, l: Long)
+val createStatement = sSession.createTable[MyTable]("mytable", 1, 0)
+createStatement.execute()
+```
+# Consistency Level
+
+By default, statements will use the same consistency as set for the entire cluster (via the `QueryOptions`).
+But, Cassandra also allows for statement-specific consistency levels to be used for insert, select, update, delete, batch, and raw statements.
+
+They all act the same way, so while the examples below focus on insert, the same rules apply to all of the above.
+
+```tut
+import com.datastax.driver.core.ConsistencyLevel
+case class Insertable(s: String, i: Int, l: Long) // same as the table
+val insertStatement = sSession.insert("mytable", Insertable("some str", 1234, 5678L))
+val consistencyInsert = insertStatement.consistency(ConsistencyLevel.ONE)
+consistencyInsert.execute()
+```
+
+And remove it if necessary, which will mean the statement will be written with the consistency level set for the cluster:
+
+```tut
+val noConsistencyInsert = insertStatement.defaultConsistency
+noConsistencyInsert.execute()
+```
+```tut:invisible
+sSession.dropKeyspace.execute()
+sSession.close()
+cluster.close()
+```

--- a/docs/cass21/src/main/tut/cass21/scalasession/consistency-level.md
+++ b/docs/cass21/src/main/tut/cass21/scalasession/consistency-level.md
@@ -38,6 +38,10 @@ And remove it if necessary, which will mean the statement will be written with t
 val noConsistencyInsert = insertStatement.defaultConsistency
 noConsistencyInsert.execute()
 ```
+
+Finally, certain consistency levels are only allowed for read vs write operations.
+See [the documentation](https://docs.datastax.com/en/cassandra/2.1/cassandra/dml/dml_config_consistency_c.html) for more details.
+In addition, batch statements can only use `SERIAL` or `LOCAL_SERIAL` level consistency.
 ```tut:invisible
 sSession.dropKeyspace.execute()
 sSession.close()

--- a/docs/cass3/src/main/tut/cass3/scalasession/consistency-level.md
+++ b/docs/cass3/src/main/tut/cass3/scalasession/consistency-level.md
@@ -1,0 +1,45 @@
+---
+layout: docs
+title: "Consistency Level"
+section: "c3"
+---
+```tut:invisible
+import com.datastax.driver.core.{Cluster, Session}
+import com.weather.scalacass.ScalaSession
+
+implicit val cluster = Cluster.builder.addContactPoint("localhost").build()
+implicit val session: Session = cluster.connect()
+
+val sSession: ScalaSession = ScalaSession("mykeyspace")
+sSession.createKeyspace("replication = {'class':'SimpleStrategy', 'replication_factor' : 1}").execute()
+
+case class MyTable(s: String, i: Int, l: Long)
+val createStatement = sSession.createTable[MyTable]("mytable", 1, 0)
+createStatement.execute()
+```
+# Consistency Level
+
+By default, statements will use the same consistency as set for the entire cluster (via the `QueryOptions`).
+But, Cassandra also allows for statement-specific consistency levels to be used for insert, select, update, delete, batch, and raw statements.
+
+They all act the same way, so while the examples below focus on insert, the same rules apply to all of the above.
+
+```tut
+import com.datastax.driver.core.ConsistencyLevel
+case class Insertable(s: String, i: Int, l: Long) // same as the table
+val insertStatement = sSession.insert("mytable", Insertable("some str", 1234, 5678L))
+val consistencyInsert = insertStatement.consistency(ConsistencyLevel.ONE)
+consistencyInsert.execute()
+```
+
+And remove it if necessary, which will mean the statement will be written with the consistency level set for the cluster:
+
+```tut
+val noConsistencyInsert = insertStatement.defaultConsistency
+noConsistencyInsert.execute()
+```
+```tut:invisible
+sSession.dropKeyspace.execute()
+sSession.close()
+cluster.close()
+```

--- a/docs/cass3/src/main/tut/cass3/scalasession/consistency-level.md
+++ b/docs/cass3/src/main/tut/cass3/scalasession/consistency-level.md
@@ -38,6 +38,10 @@ And remove it if necessary, which will mean the statement will be written with t
 val noConsistencyInsert = insertStatement.defaultConsistency
 noConsistencyInsert.execute()
 ```
+
+Finally, certain consistency levels are only allowed for read vs write operations.
+See [the documentation](https://docs.datastax.com/en/cassandra/3.0/cassandra/dml/dmlConfigConsistency.html) for more details.
+In addition, batch statements can only use `SERIAL` or `LOCAL_SERIAL` level consistency.
 ```tut:invisible
 sSession.dropKeyspace.execute()
 sSession.close()

--- a/docs/root/data/menu.yaml
+++ b/docs/root/data/menu.yaml
@@ -36,6 +36,9 @@ options:
       - title: Raw Statements
         url: cass3/scalasession/raw.html
         menu_section: ss3
+      - title: Consistency Level
+        url: cass3/scalasession/consistency-level.html
+        menu_section: ss3
 
   - title: Row Extraction
     url: cass3/row-extraction.html
@@ -95,6 +98,9 @@ options:
         menu_section: ss21
       - title: Raw Statements
         url: cass21/scalasession/raw.html
+        menu_section: ss21
+      - title: Consistency Level
+        url: cass21/scalasession/consistency-level.html
         menu_section: ss21
 
   - title: Row Extraction

--- a/scripts/makeMicrosite.sh
+++ b/scripts/makeMicrosite.sh
@@ -99,6 +99,7 @@ function clear_cassandra {
 function wait_for_cassandra {
   for i in $(seq 1 60); do
     if $1/nodetool status 2>/dev/null | grep "^UN" >/dev/null; then
+      $1/nodetool setlogginglevel ERROR 2>/dev/null
       echo "cassandra is running"
       return 0
     else

--- a/src/main/scala/com/weather/scalacass/scsession/QueryBuildingBlock.scala
+++ b/src/main/scala/com/weather/scalacass/scsession/QueryBuildingBlock.scala
@@ -112,6 +112,24 @@ private[scalacass] object QueryBuildingBlock {
     }
   }
 
+  sealed trait CassConsistency {
+    def level: Option[com.datastax.driver.core.ConsistencyLevel]
+  }
+
+  object CassConsistency {
+    import com.datastax.driver.core.{ ConsistencyLevel => CL }
+    final case class Consistency(private val _level: CL) extends CassConsistency {
+      val level = Some(_level)
+    }
+
+    case object Default extends CassConsistency {
+      val level: Option[CL] = None
+    }
+
+    def addConsistency(cl: CL): CassConsistency = Consistency(cl)
+    def removeConsistency: CassConsistency = Default
+  }
+
   trait CCBlock { this: QueryBuildingBlock =>
     protected def prefix: String
     protected def infix: String

--- a/src/main/scala/com/weather/scalacass/scsession/SCStatement.scala
+++ b/src/main/scala/com/weather/scalacass/scsession/SCStatement.scala
@@ -32,7 +32,7 @@ object SCStatement {
     def attempt(implicit ec: ExecutionContext): Future[Result[T]] = bimap(identity, identity)
   }
 
-  implicit class RightBiasedEither[+A, +B](val e: Either[A, B]) extends AnyVal {
+  private[scalacass] implicit class RightBiasedEither[+A, +B](val e: Either[A, B]) extends AnyVal {
     def map[C](fn: B => C): Either[A, C] = e.right.map(fn)
     def flatMap[AA >: A, C](fn: B => Either[AA, C]): Either[AA, C] = e.right.flatMap(fn)
     def foreach[U](fn: B => U): Unit = e match {
@@ -42,6 +42,7 @@ object SCStatement {
     }
     def getOrElse[BB >: B](or: => BB): BB = e.right.getOrElse(or)
     def valueOr[BB >: B](orFn: A => BB): BB = e.fold(orFn, identity)
+    def toOption: Option[B] = e.right.toOption
   }
   type SCBatchableStatement = SCStatement[ResultSet] with Batchable
 }

--- a/src/main/scala/com/weather/scalacass/scsession/SCStatement.scala
+++ b/src/main/scala/com/weather/scalacass/scsession/SCStatement.scala
@@ -303,6 +303,8 @@ final case class SCBatchStatement private (
 }
 object SCBatchStatement {
   trait Batchable { this: SCStatement[ResultSet] =>
+    import SCStatement.RightBiasedEither
+
     @SuppressWarnings(Array("org.wartremover.warts.Null"))
     def asBatch: Result[BoundStatement] = buildQuery.flatMap { case (queryStr, anyrefArgs) =>
       sSession.getFromCacheOrElse(queryStr, sSession.session.prepare(queryStr))

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{5} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="ERROR">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/src/test/scala/com/weather/scalacass/ConsistencyLevelUnitTest.scala
+++ b/src/test/scala/com/weather/scalacass/ConsistencyLevelUnitTest.scala
@@ -86,7 +86,7 @@ class ConsistencyLevelUnitTest extends CassandraWithTableTester(ConsistencyLevel
     checkConsistencyBatch(statement, None)
     checkConsistencyBatch(statementWithConsistency, Some(ConsistencyLevel.LOCAL_SERIAL))
     checkConsistencyBatch(statement, None)
-    checkConsistencyBatch(statementWithConsistency, Some(ConsistencyLevel.LOCAL_SERIAL))
+    checkConsistencyBatch(statementWithConsistency.consistency(ConsistencyLevel.SERIAL), Some(ConsistencyLevel.SERIAL))
     checkConsistencyBatch(statementWithNoConsistency, None)
   }
 }

--- a/src/test/scala/com/weather/scalacass/ConsistencyLevelUnitTest.scala
+++ b/src/test/scala/com/weather/scalacass/ConsistencyLevelUnitTest.scala
@@ -1,20 +1,20 @@
 package com.weather.scalacass
 
 import com.datastax.driver.core.ConsistencyLevel
-import com.weather.scalacass.scsession.{ SCBatchStatement, SCStatement }
+import com.weather.scalacass.scsession.{ SCBatchStatement, SCStatement }, SCStatement.RightBiasedEither
 import com.weather.scalacass.util.CassandraWithTableTester
 import org.scalatest.{ Assertion, OptionValues }
 
-object SessionActionsUnitTest {
+object ConsistencyLevelUnitTest {
   val db = "actionsdb"
   val table = "actionstable"
 }
 
-class SessionActionsUnitTest extends CassandraWithTableTester(SessionActionsUnitTest.db, SessionActionsUnitTest.table,
-  List("str varchar", "otherstr varchar", "d double"),
-  List("str")) with OptionValues {
-  import SessionActionsUnitTest.{ db, table }
-  lazy val ss = ScalaSession(SessionActionsUnitTest.db)(client.session)
+class ConsistencyLevelUnitTest extends CassandraWithTableTester(ConsistencyLevelUnitTest.db, ConsistencyLevelUnitTest.table,
+                                                                List("str varchar", "otherstr varchar", "d double"),
+                                                                List("str")) with OptionValues {
+  import ConsistencyLevelUnitTest.{ db, table }
+  lazy val ss = ScalaSession(ConsistencyLevelUnitTest.db)(client.session)
 
   case class Query(str: String)
   case class Insert(str: String, otherstr: String, d: Double)

--- a/src/test/scala/com/weather/scalacass/SessionActionsUnitTest.scala
+++ b/src/test/scala/com/weather/scalacass/SessionActionsUnitTest.scala
@@ -1,7 +1,61 @@
 package com.weather.scalacass
 
-class SessionActionsUnitTest extends {
-  def ssFixture = new {
+import com.datastax.driver.core.{ ConsistencyLevel, ResultSet }
+import com.weather.scalacass.scsession.SCStatement
+import com.weather.scalacass.util.CassandraWithTableTester
+import org.scalatest.{ Assertion, OptionValues }
 
+object SessionActionsUnitTest {
+  val db = "actionsdb"
+  val table = "actionstable"
+}
+
+class SessionActionsUnitTest extends CassandraWithTableTester(SessionActionsUnitTest.db, SessionActionsUnitTest.table,
+  List("str varchar", "otherstr varchar", "d double"),
+  List("str")) with OptionValues {
+  import SessionActionsUnitTest.table
+  lazy val ss = ScalaSession(SessionActionsUnitTest.db)(client.session)
+
+  case class Query(str: String)
+  case class Insert(str: String, otherstr: String, d: Double)
+  case class Update(otherstr: String, d: Double)
+
+  val insertValue = Insert("str", "otherstr", 1234.0)
+  val queryValue = Query(insertValue.str)
+  val updateValue = Update("updatedStr", 4321.0)
+
+  def checkConsistency(statement: SCStatement[ResultSet], clOpt: Option[ConsistencyLevel]): Assertion = {
+    clOpt match {
+      case Some(cl) => statement.toString should include(s"<CONSISTENCY $cl>")
+      case None     => statement.toString should not include "<CONSISTENCY"
+    }
+    val bound = statement.prepareAndBind().toOption.value
+    bound.preparedStatement.getConsistencyLevel shouldBe clOpt.orNull
   }
+  "setting consistency" should "work as expected" in {
+    val statement = ss.insert(table, insertValue)
+    val statementWithConsistency = statement.consistency(ConsistencyLevel.ONE)
+    val statementWithDiffConsistency = statementWithConsistency.consistency(ConsistencyLevel.THREE)
+    val statementWithNoConsistency = statementWithDiffConsistency.defaultConsistency
+
+    checkConsistency(statement, None)
+    checkConsistency(statementWithConsistency, Some(ConsistencyLevel.ONE))
+    checkConsistency(statement, None)
+    checkConsistency(statementWithConsistency, Some(ConsistencyLevel.ONE))
+    checkConsistency(statementWithDiffConsistency, Some(ConsistencyLevel.THREE))
+    checkConsistency(statementWithNoConsistency, None)
+  }
+
+  it should "work with updates too" in {
+    val statement = ss.update(table, updateValue, queryValue)
+    val statementWithConsistency = statement.consistency(ConsistencyLevel.LOCAL_ONE)
+    val statementWithNoConsistency = statementWithConsistency.defaultConsistency
+
+    checkConsistency(statement, None)
+    checkConsistency(statementWithConsistency, Some(ConsistencyLevel.LOCAL_ONE))
+    checkConsistency(statement, None)
+    checkConsistency(statementWithConsistency, Some(ConsistencyLevel.LOCAL_ONE))
+    checkConsistency(statementWithNoConsistency, None)
+  }
+
 }

--- a/src/test/scala/com/weather/scalacass/UpdateBehaviorTests.scala
+++ b/src/test/scala/com/weather/scalacass/UpdateBehaviorTests.scala
@@ -9,10 +9,11 @@ object UpdateBehaviorTests {
   val db = "testDB"
   val table = "testTable"
 }
-class UpdateBehaviorTests extends CassandraWithTableTester(UpdateBehaviorTests.db, UpdateBehaviorTests.table, List("str varchar", "l list<varchar>",
-  "s set<double>"), List("str")) with OptionValues {
+class UpdateBehaviorTests extends CassandraWithTableTester(UpdateBehaviorTests.db, UpdateBehaviorTests.table,
+  List("str varchar", "l list<varchar>", "s set<double>"),
+  List("str")) with OptionValues {
   import UpdateBehaviorTests.table
-  lazy val ss = ScalaSession("testDB")(client.session)
+  lazy val ss = ScalaSession(UpdateBehaviorTests.db)(client.session)
 
   case class Query(str: String)
   case class Insert(str: String, l: List[String], s: Set[Double])


### PR DESCRIPTION
closes #43 

This PR enables users to use `consistency` and `defaultConsistency` to change the consistency level of their queries.